### PR TITLE
Add randombytes for gnu linux.

### DIFF
--- a/source/randombytes/randombytes_gnu_linux.c
+++ b/source/randombytes/randombytes_gnu_linux.c
@@ -1,0 +1,28 @@
+#include <sys/syscall.h>
+
+#if defined(SYS_getrandom)
+
+#include <sys/random.h>
+
+void randombytes(unsigned char *x, unsigned long long xlen) {
+    getrandom(x, xlen, 0);
+}
+
+#else
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+
+void randombytes(unsigned char *x, unsigned long long xlen) {
+    const int randomdata = open("/dev/urandom", O_RDONLY);
+    if (randomdata < 0) {
+        memset(x, 0, xlen);
+    } else {
+        if (read(randomdata, x, xlen) < 0) {
+            memset(x, 0, xlen);
+        }
+    }
+}
+
+#endif

--- a/source/randombytes/randombytes_gnu_linux.c
+++ b/source/randombytes/randombytes_gnu_linux.c
@@ -10,6 +10,9 @@ void randombytes(unsigned char *x, unsigned long long xlen) {
 
 #else
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
@@ -17,10 +20,12 @@ void randombytes(unsigned char *x, unsigned long long xlen) {
 void randombytes(unsigned char *x, unsigned long long xlen) {
     const int randomdata = open("/dev/urandom", O_RDONLY);
     if (randomdata < 0) {
-        memset(x, 0, xlen);
+        printf("randombytes failed opening /dev/urandom: %s\n", strerror(errno));
+        exit(errno);
     } else {
         if (read(randomdata, x, xlen) < 0) {
-            memset(x, 0, xlen);
+            printf("randombytes failed reading from /dev/urandom: %s\n", strerror(errno));
+            exit(errno);
         }
     }
 }


### PR DESCRIPTION
This PR adds `randombytes` for gnu linux systems.

`getrandom` will be called if available (i.e. if glibc is not older than version 2.25). Otherwise random values will be read from `/dev/urandom`. If this fails the whole program will exit with a non-zero return value.

Additional information:
- [Introduction of `getrandom`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c6e9d6f38894798696f23c8084ca7edbf16ee895)
- [why use `/dev/urandom`](https://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/).